### PR TITLE
Rewind after image_info($fh)

### DIFF
--- a/lib/Image/Info.pm
+++ b/lib/Image/Info.pm
@@ -76,6 +76,7 @@ sub _image_info_for_format
         $info->clean_up;
     };
     return { error => $@ } if $@;
+    seek($source, 0, 0) or return _os_err("Can't rewind");
     return wantarray ? @$info : $info->[0];
 }
 


### PR DESCRIPTION
Image::Info::image_type($fh) doesn't change file handle's position because it rewinds in _head(), but Image::Info::image_info($fh) does change file handle's position because it moves the position in Image::Info::$type::process_file() again after it rewinds in _head().

This PR fixes the issue by rewinding the position at the end of _image_info_for_format(). I omitted a hack for IO::String in _head() as it seems IO::String supports seek() correctly now, and if we go paranoid, it might be better to rewind before we return an error hashref.
