### PR TITLE
Fix uninitialized warning

### DIFF
--- a/lib/Image/TIFF.pm
+++ b/lib/Image/TIFF.pm
@@ -966,7 +966,7 @@ sub add_fields
 		$maker =~ /^([A-Z]+)/; $maker = $1 || ''; # "OLYMPUS ..." > "OLYMPUS"
 
 		# if 'Panasonic' doesn't exist, try 'Panasonic DMC-FZ5'
-		$maker = $self->{Make}.' '.$self->{Model}
+		$maker = join " " => grep m/\S/ => $self->{Make}, $self->{Model}
 		    unless exists $makernotes{$maker};
 
 		if (exists $makernotes{$maker}) {


### PR DESCRIPTION
Use of uninitialized value in concatenation (.) or string at ../site_perl/5.28.0/Image/TIFF.pm line 970.