### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/dev/Info.pm.tmpl
+++ b/dev/Info.pm.tmpl
@@ -16,14 +16,13 @@ package Image::Info;
 # Currently maintained by Slaven Rezic - (c) 2008 - 2023.
 
 use strict;
-use vars qw($VERSION @EXPORT_OK);
 
-$VERSION = '1.44';
+our $VERSION = '1.44';
 
 require Exporter;
 *import = \&Exporter::import;
 
-@EXPORT_OK = qw(image_info dim html_dim image_type determine_file_format);
+our @EXPORT_OK = qw(image_info dim html_dim image_type determine_file_format);
 
 # already required and failed sub-modules are remembered here
 my %mod_failure;

--- a/lib/Bundle/Image/Info/Everything.pm
+++ b/lib/Bundle/Image/Info/Everything.pm
@@ -3,8 +3,7 @@
 package Bundle::Image::Info::Everything;
 
 use strict;
-use vars qw($VERSION);
-$VERSION = '0.02';
+our $VERSION = '0.02';
 
 1;
 

--- a/lib/Bundle/Image/Info/PNG.pm
+++ b/lib/Bundle/Image/Info/PNG.pm
@@ -3,8 +3,7 @@
 package Bundle::Image::Info::PNG;
 
 use strict;
-use vars qw($VERSION);
-$VERSION = '0.02';
+our $VERSION = '0.02';
 
 1;
 

--- a/lib/Bundle/Image/Info/SVG.pm
+++ b/lib/Bundle/Image/Info/SVG.pm
@@ -3,8 +3,7 @@
 package Bundle::Image::Info::SVG;
 
 use strict;
-use vars qw($VERSION);
-$VERSION = '0.02';
+our $VERSION = '0.02';
 
 1;
 

--- a/lib/Bundle/Image/Info/XBM.pm
+++ b/lib/Bundle/Image/Info/XBM.pm
@@ -3,8 +3,7 @@
 package Bundle::Image::Info::XBM;
 
 use strict;
-use vars qw($VERSION);
-$VERSION = '0.02';
+our $VERSION = '0.02';
 
 1;
 

--- a/lib/Bundle/Image/Info/XPM.pm
+++ b/lib/Bundle/Image/Info/XPM.pm
@@ -3,8 +3,7 @@
 package Bundle::Image::Info::XPM;
 
 use strict;
-use vars qw($VERSION);
-$VERSION = '0.02';
+our $VERSION = '0.02';
 
 1;
 

--- a/lib/Image/Info.pm
+++ b/lib/Image/Info.pm
@@ -16,14 +16,13 @@ package Image::Info;
 # Currently maintained by Slaven Rezic - (c) 2008 - 2023.
 
 use strict;
-use vars qw($VERSION @EXPORT_OK);
 
-$VERSION = '1.44';
+our $VERSION = '1.44';
 
 require Exporter;
 *import = \&Exporter::import;
 
-@EXPORT_OK = qw(image_info dim html_dim image_type determine_file_format);
+our @EXPORT_OK = qw(image_info dim html_dim image_type determine_file_format);
 
 # already required and failed sub-modules are remembered here
 my %mod_failure;

--- a/lib/Image/Info/PNG.pm
+++ b/lib/Image/Info/PNG.pm
@@ -18,9 +18,8 @@ key.
 =cut
 
 use strict;
-use vars qw/$VERSION/;
 
-$VERSION = 1.03;
+our $VERSION = 1.03;
 
 # Test for Compress::Zlib (for reading zTXt chunks)
 my $have_zlib = 0;

--- a/lib/Image/Info/PPM.pm
+++ b/lib/Image/Info/PPM.pm
@@ -18,9 +18,8 @@ All information available is extracted.
 =cut
 
 use strict;
-use vars qw/$VERSION/;
 
-$VERSION = 0.04;
+our $VERSION = 0.04;
 
 sub process_file {
     my($info, $fh) = @_;

--- a/lib/Image/Info/SVG.pm
+++ b/lib/Image/Info/SVG.pm
@@ -11,8 +11,8 @@
 package Image::Info::SVG;
 
 use strict;
-use vars qw($VERSION @PREFER_MODULE $USING_MODULE);
-$VERSION = '2.04';
+our (@PREFER_MODULE, $USING_MODULE);
+our $VERSION = '2.04';
 
 @PREFER_MODULE = qw(Image::Info::SVG::XMLLibXMLReader
 		    Image::Info::SVG::XMLSimple

--- a/lib/Image/Info/SVG/XMLLibXMLReader.pm
+++ b/lib/Image/Info/SVG/XMLLibXMLReader.pm
@@ -15,8 +15,7 @@
 package Image::Info::SVG::XMLLibXMLReader;
 
 use strict;
-use vars qw($VERSION);
-$VERSION = '1.05';
+our $VERSION = '1.05';
 
 use XML::LibXML::Reader;
 

--- a/lib/Image/Info/WBMP.pm
+++ b/lib/Image/Info/WBMP.pm
@@ -9,13 +9,12 @@
 package Image::Info::WBMP;
 
 use strict;
-use vars qw($VERSION @EXPORT_OK);
-$VERSION = '0.01';
+our $VERSION = '0.01';
 
 require Exporter;
 *import = \&Exporter::import;
 
-@EXPORT_OK = qw(wbmp_image_info);
+our @EXPORT_OK = qw(wbmp_image_info);
 
 sub process_file {
     my($info, $fh) = @_;

--- a/lib/Image/Info/WEBP.pm
+++ b/lib/Image/Info/WEBP.pm
@@ -28,8 +28,7 @@ package Image::Info::WEBP;
 use strict;
 use warnings;
 
-use vars qw($VERSION);
-$VERSION = '0.01';
+our $VERSION = '0.01';
 
 sub my_read
 {

--- a/lib/Image/TIFF.pm
+++ b/lib/Image/TIFF.pm
@@ -7,9 +7,8 @@ package Image::TIFF;
 # modify it under the same terms as Perl v5.8.8 itself.
 
 use strict;
-use vars qw($VERSION);
 
-$VERSION = '1.11';
+our $VERSION = '1.11';
 
 my @types = (
   [ "BYTE",      "C1", 1],


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under 5.06+.