### PR TITLE
Extract Exif SRATIONAL values appropriately

### DIFF
--- a/lib/Image/TIFF.pm
+++ b/lib/Image/TIFF.pm
@@ -18,7 +18,6 @@ my @types = (
   [ "RATIONAL",  "N2", 8],
   [ "SBYTE",     "c1", 1],
   [ "UNDEFINED", "a1", 1],
-  [ "BINARY",    "a1", 1],  # treat binary data as UNDEFINED	
   [ "SSHORT",    "n1", 2],
   [ "SLONG",     "N1", 4],
   [ "SRATIONAL", "N2", 8],

--- a/t/bad_exif.t
+++ b/t/bad_exif.t
@@ -13,7 +13,7 @@ use Image::Info;
 
   my $info = Image::Info::image_info("$Bin/../img/bad-exif-1.jpg");
   ok( ! $info->{error}, "no error on bad EXIF data" ) or diag( "Got Error: $info->{error}" );
-  is( join("\n", @{ $info->{resolution} }), "75 dpi\n3314/3306 dpi", "resolution as expected" );
+  is( join("\n", @{ $info->{resolution} }), "75 dpi\n180 dpi", "resolution as expected" );
 
   isnt "@warnings", "", 'seen expected warnings';
 }

--- a/t/exif.t
+++ b/t/exif.t
@@ -7,7 +7,7 @@ use strict;
 
 BEGIN
    {
-   plan tests => 7;
+   plan tests => 9;
    chdir 't' if -d 't';
    use lib '../lib';
    use_ok ("Image::Info") or die($@);
@@ -30,5 +30,8 @@ is ($i->{'Olympus-CameraID'}, 'OLYMPUS DIGITAL CAMERA', 'Olympus-CameraID');
 
 isnt ($i->{UserComment}, "ASCII", 'UserComment');
 like ($i->{UserComment}, qr/^\s+\z/, 'UserComment');
+
+isa_ok ($i->{ExposureBiasValue}, 'Image::TIFF::Rational');
+is ("$i->{ExposureBiasValue}", "0/10", 'ExposureBiasValue');
 
 is (dim($i), '320x240', 'dim()');


### PR DESCRIPTION
Image::Info fails to extract Exif data of type SRATIONAL. It misunderstands SRATIONAL values as SLONG values.

This PR enables to appropriately extract SRATIONAL values such as ExposureBiasValue, GPSLatitude, and GPSLongitude.