### PR TITLE
fallback on viewBox if needed

### DIFF
--- a/lib/Image/Info/SVG/XMLLibXMLReader.pm
+++ b/lib/Image/Info/SVG/XMLLibXMLReader.pm
@@ -40,7 +40,7 @@ sub process_file {
     if ($root_name eq 'svg') {
 	my @dimensions;
 	my $viewbox = $reader->getAttribute('viewBox');
-	@dimensions = split(/(\w|,)/, $viewbox) if $viewbox;
+	@dimensions = split(/(?: |,)/, $viewbox) if $viewbox;
 	my $height = $reader->getAttribute('height') || $dimensions[3];
 	my $width  = $reader->getAttribute('width')  || $dimensions[2];
 	$info->push_info(0, 'height', $height);

--- a/lib/Image/Info/SVG/XMLLibXMLReader.pm
+++ b/lib/Image/Info/SVG/XMLLibXMLReader.pm
@@ -41,8 +41,12 @@ sub process_file {
 	my @dimensions;
 	my $viewbox = $reader->getAttribute('viewBox');
 	@dimensions = split(/(?: |,)/, $viewbox) if $viewbox;
-	my $height = $reader->getAttribute('height') || $dimensions[3];
-	my $width  = $reader->getAttribute('width')  || $dimensions[2];
+	my $height =
+        $reader->getAttribute('height') ||
+        $dimensions[3] ? int($dimensions[3]) : undef;
+	my $width  =
+        $reader->getAttribute('width')  ||
+        $dimensions[2] ? int($dimensions[2]) : undef;
 	$info->push_info(0, 'height', $height);
 	$info->push_info(0, 'width', $width);
 

--- a/lib/Image/Info/SVG/XMLLibXMLReader.pm
+++ b/lib/Image/Info/SVG/XMLLibXMLReader.pm
@@ -38,8 +38,13 @@ sub process_file {
     # first XML element
     my $root_name = $reader->name;
     if ($root_name eq 'svg') {
-	$info->push_info(0, 'height', $reader->getAttribute('height'));
-	$info->push_info(0, 'width', $reader->getAttribute('width'));
+	my @dimensions;
+	my $viewbox = $reader->getAttribute('viewBox');
+	@dimensions = split(/(\w|,)/, $viewbox) if $viewbox;
+	my $height = $reader->getAttribute('height') || $dimensions[3];
+	my $width  = $reader->getAttribute('width')  || $dimensions[2];
+	$info->push_info(0, 'height', $height);
+	$info->push_info(0, 'width', $width);
 
 	my $version = $reader->getAttribute('version') || 'unknown';
 	$info->push_info(0, 'SVG_Version', $version);

--- a/lib/Image/Info/SVG/XMLSimple.pm
+++ b/lib/Image/Info/SVG/XMLSimple.pm
@@ -52,8 +52,18 @@ sub process_file {
     # "image/svg+xml" is the official MIME type
     $info->push_info(0, "file_media_type" => "image/svg+xml");
 
-    $info->push_info(0, "height", $img->{height});
-    $info->push_info(0, "width", $img->{width});
+    my @dimensions;
+    @dimensions = split(/(?: |,)/, $img->{viewBox}) if $img->{viewBox};
+
+    my $height =
+        $img->{height} ||
+        $dimensions[3] ? int($dimensions[3]) : undef;
+    my $width =
+        $img->{width} ||
+        $dimensions[2] ? int($dimensions[2]) : undef;
+
+    $info->push_info(0, "height", $height);
+    $info->push_info(0, "width", $width);
     $info->push_info(0, "SVG_StandAlone", $info{standalone});
     $info->push_info(0, "SVG_Version", $img->{version} || 'unknown');
 


### PR DESCRIPTION
Some SVG file don't have size/heigth attributes, but only a viewbox attribute, such as this one:
https://rendez-vous.renater.fr/home/assets/images/logo.svg

ImageMagick does use those values to compute image dimensions, the following PR enforces the same behaviour.